### PR TITLE
Making the B&B Solver Parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ opt-level = 3
 codegen-units = 1
 
 [profile.dev]
-codegen-units = 128
-opt-level = 0
+codegen-units = 1
+opt-level = 3
 lto = false
 incremental = true
 

--- a/src/branch_subproblem.rs
+++ b/src/branch_subproblem.rs
@@ -27,6 +27,7 @@ pub fn get_sub_problem_solver(
     }
 }
 
+#[derive(Clone)]
 pub struct ClarabelSubProblemSolver {
     q: CscMatrix,
     c: Array1<f64>,

--- a/src/branchbound.rs
+++ b/src/branchbound.rs
@@ -2,6 +2,7 @@ use crate::qubo::Qubo;
 use ndarray::Array1;
 use std::ops::Index;
 use std::time;
+use rayon::prelude::*;
 
 use crate::branch_node::QuboBBNode;
 use crate::branch_stratagy::BranchStrategy;
@@ -30,6 +31,33 @@ pub struct BBSolver {
     pub options: SolverOptions,
 }
 
+pub enum Event {
+    UpdateBestSolution(Array1<f64>),
+    AddBranches(QuboBBNode, QuboBBNode),
+    Nill
+}
+
+pub enum SolverLoggingAction{
+    NodeVisited,
+    NodeProcessed,
+    NodeSolved,
+}
+
+pub enum PruneAction{
+    Prune,
+    Dont
+}
+
+pub enum IntegerFeasibility{
+    IntegerFeasible(Array1<f64>),
+    NotIntegerFeasible
+}
+
+pub struct ProcessNodeState{
+    pub prune_action: PruneAction,
+    pub event: Option<Event>
+}
+
 impl BBSolver {
     /// Creates a new B&B solver
     pub fn new(qubo: Qubo, options: SolverOptions) -> Self {
@@ -38,6 +66,10 @@ impl BBSolver {
 
         let subproblem_solver = get_sub_problem_solver(&qubo, &options.sub_problem_solver);
         let branch_strategy = BranchStrategy::get_branch_strategy(&options.branch_strategy);
+        let start_time = time::SystemTime::now()
+            .duration_since(time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs_f64();
 
         Self {
             qubo,
@@ -47,7 +79,7 @@ impl BBSolver {
             nodes_processed: 0,
             nodes_visited: 0,
             nodes_solved: 0,
-            time_start: 0.0,
+            time_start: start_time,
             branch_strategy,
             subproblem_solver,
             options,
@@ -63,7 +95,10 @@ impl BBSolver {
     /// The main solve function of the B&B algorithm
     pub fn solve(&mut self) -> (Array1<f64>, f64) {
         // preprocess the problem
-        // self.preprocess_initial();
+        let initial_fixed = self.options.fixed_variables.clone();
+
+        self.options.fixed_variables =
+            compute_iterative_persistence(&self.qubo, &initial_fixed, self.qubo.num_x());
 
         // create the root node
         let root_node = QuboBBNode {
@@ -93,68 +128,39 @@ impl BBSolver {
 
         // until we have hit a termination condition, we will keep iterating
         while !(*self).termination_condition() {
-            // get the next node if it exists
-            let next_node = self.get_next_node();
 
-            // there are no more nodes to process, so we are done iterating
-            if next_node.is_none() {
+            // get the most recent 25 nodes to process
+            let nodes = self.get_next_nodes(self.options.threads);
+
+            if nodes.is_empty() {
                 break;
             }
 
-            // unwrap the node
-            let mut node = next_node.unwrap();
+            let process_results = nodes.par_iter().map(|node| {
+                self.process_node(node.clone())
+            }).collect::<Vec<ProcessNodeState>>();
 
-            // as we are processing the node, we increment the number of nodes processed
-            self.nodes_processed += 1;
+            self.nodes_processed += nodes.len();
 
-            // see if there are any variables we can fix
-            node.fixed_variables =
-                compute_iterative_persistence(&self.qubo, &node.fixed_variables, self.qubo.num_x());
-
-            // with this expanded set can we prune the node?
-            if self.can_prune(&node) {
-                continue;
-            }
-
-            // We now need to solve the node to generate the lower bound and solution
-            let (lower_bound, solution) = self.solve_node(&node);
-            self.nodes_solved += 1;
-
-            if lower_bound > self.best_solution_value {
-                continue;
-            }
-
-            // inject the solution back into the node
-            node.solution = solution.clone();
-
-            // check if integer feasible solution
-            // if not all variables are fixed, we can still check if we are 'near' integer-feasible (within 1E-10) of 0 or 1
-            let (is_int_feasible, rounded_sol) = check_integer_feasibility(&node);
-
-            if is_int_feasible {
-                self.update_solution_if_better(&rounded_sol);
-                println!(
-                    "Integer Feasible Solution Found: {} {}",
-                    rounded_sol,
-                    node.solution.clone()
-                );
-            }
-
-            // determine what variable we are branching on
-            let branch_id = self.make_branch(&node);
-
-            // generate the branches
-            let (zero_branch, one_branch) = Self::branch(node, branch_id, lower_bound, solution);
-
-            // add the branches to the list of nodes
-            self.nodes.push(zero_branch);
-            self.nodes.push(one_branch);
-
-            if self.nodes_solved % 100 == 0 {
-                if self.options.verbose {
-                    generate_output_line(&self);
+            for state in process_results {
+                match state.event {
+                    Some(Event::UpdateBestSolution(solution)) => {
+                        self.update_solution_if_better(&solution);
+                    },
+                    Some(Event::AddBranches(zero_branch, one_branch)) => {
+                        self.nodes.push(zero_branch);
+                        self.nodes.push(one_branch);
+                        self.nodes_solved += 1;
+                    },
+                    _ => {}
                 }
             }
+
+
+            if self.options.verbose {
+                generate_output_line(&self);
+            }
+
         }
 
         if self.options.verbose {
@@ -164,11 +170,11 @@ impl BBSolver {
         (self.best_solution.clone(), self.best_solution_value)
     }
 
-    /// Checks if we can prune the node, based on the lower bound and best solution
-    pub fn can_prune(&mut self, node: &QuboBBNode) -> bool {
-        // if the lower bound is greater than the best solution, then we can prune
+
+    /// Checks if we can prune the node, based on the lower bound and best solution, returns an action
+    pub fn can_prune_action(&self, node: &QuboBBNode) -> (PruneAction, Event) {
         if node.lower_bound > self.best_solution_value {
-            return true;
+            return (PruneAction::Prune, Event::Nill);
         }
 
         // if the solution is complete, then we can update the best solution if better
@@ -182,15 +188,74 @@ impl BBSolver {
 
             // evaluate the solution against the best solution we have so far
             // if we have a better solution update it
-            self.update_solution_if_better(&solution);
-            return true;
+            return (PruneAction::Prune, Event::UpdateBestSolution(solution));
         }
 
-        // if we cannot remove the node, then we return false as we cannot provably prune it yet
-        false
+        (PruneAction::Dont, Event::Nill)
     }
 
-    /// update the best solution if better then the current best solution
+    /// main loop of the branch and bound algorithm
+    pub fn process_node(&self, node: QuboBBNode) -> ProcessNodeState {
+
+        let mut x = ProcessNodeState {
+            prune_action: PruneAction::Dont,
+            event: None
+        };
+
+        let mut node = node.clone();
+
+        // see if there are any variables we can fix
+        node.fixed_variables =
+            compute_iterative_persistence(&self.qubo, &node.fixed_variables, self.qubo.num_x());
+
+        // with this expanded set can we prune the node?
+        let (prune_action, event) = self.can_prune_action(&node);
+
+        match prune_action {
+            PruneAction::Prune => {
+                x.prune_action = PruneAction::Prune;
+
+                match event {
+                    Event::UpdateBestSolution(solution) => {
+                        x.event = Some(Event::UpdateBestSolution(solution));
+                    },
+                    _ => {}
+                }
+
+                return x;
+            },
+            PruneAction::Dont => {}
+        };
+
+        // We now need to solve the node to generate the lower bound and solution
+        let (lower_bound, solution) = self.solve_node(&node);
+
+        // inject the solution back into the node
+        node.solution = solution.clone();
+
+        // check if integer feasible solution
+        // if not all variables are fixed, we can still check if we are 'near' integer-feasible (within 1E-10) of 0 or 1
+        let (is_int_feasible, rounded_sol) = check_integer_feasibility(&node);
+
+        if is_int_feasible {
+            x.event = Some(Event::UpdateBestSolution(rounded_sol));
+            return x;
+        }
+
+        // determine what variable we are branching on
+        let branch_id = self.make_branch(&node);
+
+        // generate the branches
+        let (zero_branch, one_branch) = Self::branch(node, branch_id, lower_bound, solution);
+
+        // add the branches to the list of nodes
+        x.event = Some(Event::AddBranches(zero_branch, one_branch));;
+
+        x
+
+    }
+
+    /// update the best solution if better than the current best solution
     pub fn update_solution_if_better(&mut self, solution: &Array1<f64>) {
         let solution_value = self.qubo.eval(solution);
         if solution_value < self.best_solution_value {
@@ -201,6 +266,7 @@ impl BBSolver {
 
     /// This function is used to get the next node to process, popping it from the list of nodes
     pub fn get_next_node(&mut self) -> Option<QuboBBNode> {
+
         while !self.nodes.is_empty() {
             // we pull a node from our node list
             let optional_node = self.nodes.pop();
@@ -213,36 +279,46 @@ impl BBSolver {
             self.nodes_visited += 1;
 
             // if we can't prune it, then we return it
-            if !self.can_prune(&node) {
-                return Some(node);
+            let (prune, event) = self.can_prune_action(&node);
+
+            match event {
+                Event::UpdateBestSolution(solution) => {
+                    self.update_solution_if_better(&solution);
+                },
+                _ => {}
+            }
+
+            match prune {
+                PruneAction::Dont => {
+                    return Some(node);
+                },
+                PruneAction::Prune => {}
             }
         }
+
         None
     }
 
-    /// This function is used to get the next N nodes to process
-    ///
-    /// It is not guaranteed to generate a vector of N nodes, as there might not be N nodes to get
-    /// can return an empty list of nodes!
     pub fn get_next_nodes(&mut self, n: usize) -> Vec<QuboBBNode> {
-        let mut selected_nodes = Vec::new();
 
-        // get the next node until we have n nodes or exhausted the list of nodes
-        while selected_nodes.len() < n {
-            // get the next node
-            let possible_node = self.get_next_node();
+        let mut nodes = Vec::new();
 
-            match possible_node {
+        while nodes.len() <= n {
+
+            let next_node = self.get_next_node();
+
+            match next_node {
                 Some(node) => {
-                    selected_nodes.push(node);
-                }
+                    nodes.push(node);
+                },
                 None => {
-                    return selected_nodes;
+                    break;
                 }
             }
+
         }
 
-        selected_nodes
+        nodes
     }
 
     /// Checks for termination conditions of the B&B algorithm, such as time limit or no more nodes
@@ -302,13 +378,6 @@ impl BBSolver {
         self.subproblem_solver.solve(self, node)
     }
 
-    pub fn preprocess_initial(&mut self) {
-        // compute an initial set of persistent variables with the fixed variables
-        let initial_fixed = self.options.fixed_variables.clone();
-
-        self.options.fixed_variables =
-            compute_iterative_persistence(&self.qubo, &initial_fixed, self.qubo.num_x());
-    }
 }
 
 #[cfg(test)]
@@ -356,8 +425,9 @@ mod tests {
         options.verbose = true;
         options.max_time = 1000.0;
         options.branch_strategy = BranchStrategySelection::Random;
+        options.threads = 32;
 
-        let mut solver = branchbound::BBSolver::new(p_fixed, SolverOptions::new());
+        let mut solver = branchbound::BBSolver::new(p_fixed, options);
         solver.warm_start(guess);
         solver.solve();
     }

--- a/src/branchbound.rs
+++ b/src/branchbound.rs
@@ -424,7 +424,7 @@ mod tests {
         let mut options = SolverOptions::new();
         options.verbose = true;
         options.max_time = 1000.0;
-        options.branch_strategy = BranchStrategySelection::Random;
+        options.branch_strategy = BranchStrategySelection::MostViolated;
         options.threads = 32;
 
         let mut solver = branchbound::BBSolver::new(p_fixed, options);

--- a/src/branchboundlogger.rs
+++ b/src/branchboundlogger.rs
@@ -1,3 +1,4 @@
+use std::time;
 use crate::branchbound::BBSolver;
 
 pub fn output_header(solver_instance: &BBSolver) {
@@ -22,19 +23,28 @@ pub fn generate_output_line(solver_instance: &BBSolver) {
         .iter()
         .map(|x| x.lower_bound)
         .fold(f64::INFINITY, |a, b| a.min(b));
-    let gap = ((upper_bound - lower_bound) / upper_bound * 100.0 + 1E-5).abs();
+    let gap = 100.0*(upper_bound - lower_bound) / (upper_bound  + 1E-5).abs();
+    let gap = gap.max(0.0);
+    let lower_bound = lower_bound.min(upper_bound);
     println!("{num_nodes} | {upper_bound} | {lower_bound} | {gap}");
 }
 
 pub fn generate_exit_line(solver_instance: &BBSolver) {
     let solution = solver_instance.best_solution.clone();
     let solution_value = solver_instance.best_solution_value;
-    let nodes_visited = solver_instance.nodes_visited;
+    let nodes_solved = solver_instance.nodes_solved;
+    let current_time =time::SystemTime::now()
+        .duration_since(time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64();
+    let time_passed = current_time - solver_instance.time_start;
     println!("------------------------------------------------------");
     println!("Branch and Bound Solver Finished");
     println!("Best Solution: {solution}");
     println!("Best Solution Value: {solution_value}");
-    println!("Nodes Visited: {nodes_visited}");
+    println!("Nodes Visited: {nodes_solved}");
+    println!("Time to Solve: {time_passed}");
+    println!("------------------------------------------------------");
 }
 
 pub fn output_warm_start_info(solver_instance: &BBSolver) {
@@ -61,8 +71,6 @@ mod tests {
             Qubo::new_with_c(CsMat::eye(3), Array1::from_vec(vec![1.0, -2.0, 3.0])),
             SolverOptions::new(),
         );
-
-        solver.preprocess_initial();
 
         let s = solver.solve();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod tests {
             generator: JsfLarge::default(),
         };
 
-        Qubo::make_random_qubo(50, &mut prng, 0.2)
+        Qubo::make_random_qubo(50, &mut prng, 0.1)
     }
 
     pub(crate) fn get_min_obj(p: &Qubo, xs: &Vec<Array1<f64>>) -> f64 {


### PR DESCRIPTION
Here we are adding the components for parallelism to the solver. The model is somewhat simplistic in that, we have removed all functions that are in the main solve loop from needing a mutable reference to solve, except getting BBnodes and update solution. 

This is based on making an event driven architecture, where the instead of doing updates in place, it passes enum's for the what action should take place, that is then processed in the main thread. 

Minor display bug fix in the display functionality.