### PR TITLE
making way for new subsolvers to be added to hercules

### DIFF
--- a/src/branch_stratagy.rs
+++ b/src/branch_stratagy.rs
@@ -210,6 +210,8 @@ pub fn full_strong_branching(solver: &BBSolver, node: &QuboBBNode) -> usize {
         }
     }
 
+
+
     best_variable
 }
 
@@ -224,11 +226,11 @@ pub fn partial_strong_branching(solver: &BBSolver, node: &QuboBBNode) -> usize {
     // scan through the unfixed variable and compute the scores
     for &i in &unfixed_vars {
         // find the minimum of the two objective changes
-        score[i] = zero_flip[i].abs().max(one_flip[i].abs());
+        score[i] = zero_flip[i].abs()*(one_flip[i].abs());
     }
 
     let mut indx = unfixed_vars.clone();
-    indx.sort_by(|&i, &j| score[i].total_cmp(&score[j]));
+    indx.sort_by(|&i, &j| score[i].total_cmp(&score[j]).reverse());
 
     // test strong branching on the most likely candidate set of 5 variables
 
@@ -262,10 +264,10 @@ pub fn partial_strong_branching(solver: &BBSolver, node: &QuboBBNode) -> usize {
         let bound_0 = solver.subproblem_solver.solve_lower_bound(solver, &node_0);
         let bound_1 = solver.subproblem_solver.solve_lower_bound(solver, &node_1);
 
-        let score = bound_0.0.min(bound_1.0);
+        let score_i = (bound_0.0 - node.lower_bound).abs()*(bound_1.0 - node.lower_bound).abs();
 
-        if score > best_score {
-            best_score = score;
+        if score_i > best_score {
+            best_score = score_i;
             best_variable = j;
         }
     }
@@ -316,7 +318,7 @@ pub fn worst_approximation(solver: &BBSolver, node: &QuboBBNode) -> usize {
         }
 
         // take the product of the approximate objective change for the zero and one flips as the metric
-        let min_obj_gain = zero_flip[i].abs().max(one_flip[i].abs());
+        let min_obj_gain = zero_flip[i].abs()*(one_flip[i].abs());
 
         // if it is the highest growing variable, then update the tracking variables
         if min_obj_gain > worst_approximation {

--- a/src/branch_subproblem.rs
+++ b/src/branch_subproblem.rs
@@ -1,26 +1,27 @@
 use crate::branch_node::QuboBBNode;
 use crate::branchbound::BBSolver;
 use crate::qubo::Qubo;
-use crate::subproblemsolvers::clarabel_qp::ClarabelSubProblemSolver;
+use crate::subproblemsolvers::clarabel_qp::ClarabelQPSolver;
 use ndarray::Array1;
+use crate::subproblemsolvers::clarabel_lp::ClarabelLPSolver;
 
 pub type SubProblemResult = (f64, Array1<f64>);
 
 pub trait SubProblemSolver {
-    fn new(qubo: &Qubo) -> Self;
-
     fn solve_lower_bound(&self, bbsolver: &BBSolver, node: &QuboBBNode) -> SubProblemResult;
 }
 
 pub enum SubProblemSelection {
     ClarabelQP,
+    ClarabelLP,
 }
 
 pub fn get_sub_problem_solver(
     qubo: &Qubo,
     sub_problem_selection: &SubProblemSelection,
-) -> ClarabelSubProblemSolver {
+) -> Box<dyn SubProblemSolver + Sync> {
     match sub_problem_selection {
-        SubProblemSelection::ClarabelQP => ClarabelSubProblemSolver::new(qubo),
+        SubProblemSelection::ClarabelQP => Box::new(ClarabelQPSolver::new(qubo)),
+        SubProblemSelection::ClarabelLP => Box::new(ClarabelLPSolver::new(qubo)),
     }
 }

--- a/src/branchbound.rs
+++ b/src/branchbound.rs
@@ -14,7 +14,6 @@ use crate::lower_bound::li_lower_bound;
 use crate::preprocess;
 use crate::preprocess::preprocess_qubo;
 use crate::solver_options::SolverOptions;
-use crate::subproblemsolvers::clarabel_qp::ClarabelSubProblemSolver;
 use std::collections::BinaryHeap;
 
 /// Struct for the B&B Solver
@@ -29,7 +28,7 @@ pub struct BBSolver {
     pub nodes_visited: usize,
     pub time_start: f64,
     pub branch_strategy: BranchStrategy,
-    pub subproblem_solver: ClarabelSubProblemSolver,
+    pub subproblem_solver: Box<dyn SubProblemSolver + Sync>,
     pub options: SolverOptions,
     pub early_stop: bool,
     pub solver_logger: SolverOutputLogger,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod variable_reduction;
 
 pub mod subproblemsolvers {
     pub mod clarabel_qp;
+    pub mod clarabel_lp;
 }
 
 #[allow(clippy::wildcard_imports)]

--- a/src/subproblemsolvers.rs
+++ b/src/subproblemsolvers.rs
@@ -1,1 +1,2 @@
 pub mod clarabel_qp;
+pub mod clarabel_lp;

--- a/src/subproblemsolvers/clarabel_lp.rs
+++ b/src/subproblemsolvers/clarabel_lp.rs
@@ -33,23 +33,19 @@ impl SubProblemSolver for ClarabelLPSolver {
 
     fn solve_lower_bound(&self, bbsolver: &BBSolver, node: &QuboBBNode) -> SubProblemResult {
 
-        let mut settings = DefaultSettings {
-            verbose: false,
-            ..Default::default()
-        };
 
         // this solves the glover's reformulation of the problem, e.g. the QUBO is transformed into a linear problem
 
-        settings.presolve_enable = true;
-
-        // first find the number of edges that we are dealing with in this qubo
-        let edges = &bbsolver.qubo.q.iter().filter(|(_, (i,j))| i < j).collect::<Vec<_>>();
-        let edge_weights = Array1::from(edges.iter().map(|&v| v.0));
-        let num_aux_vars = edge_weights.count();
-
-        let num_unfixed = bbsolver.qubo.num_x() - node.fixed_variables.len();
-
-        let P = CscMatrix::zeros((num_unfixed + num_aux_vars, num_unfixed + num_aux_vars));
+        // settings.presolve_enable = true;
+        //
+        // // first find the number of edges that we are dealing with in this qubo
+        // let edges = &bbsolver.qubo.q.iter().filter(|(_, (i,j))| i < j).collect::<Vec<_>>();
+        // let edge_weights = Array1::from(edges.iter().map(|&v| v.0));
+        // let num_aux_vars = edge_weights.count();
+        //
+        // let num_unfixed = bbsolver.qubo.num_x() - node.fixed_variables.len();
+        //
+        // let P = CscMatrix::zeros((num_unfixed + num_aux_vars, num_unfixed + num_aux_vars));
 
         !unimplemented!("This function is not implemented yet")
     }

--- a/src/subproblemsolvers/clarabel_lp.rs
+++ b/src/subproblemsolvers/clarabel_lp.rs
@@ -1,0 +1,56 @@
+use clarabel::algebra::CscMatrix;
+use clarabel::solver::DefaultSettings;
+use ndarray::Array1;
+use sprs::CsMat;
+use crate::branch_node::QuboBBNode;
+use crate::branch_subproblem::SubProblemSolver;
+use crate::branchbound::BBSolver;
+use crate::qubo::Qubo;
+use crate::branch_subproblem::SubProblemResult;
+
+#[derive(Clone)]
+pub struct ClarabelLPSolver {
+    pub q: CscMatrix,
+    pub c: Array1<f64>,
+}
+
+impl ClarabelLPSolver {
+    pub fn make_cb_form(p0: &CsMat<f64>) -> CscMatrix {
+        let (t, y, u) = p0.to_csc().into_raw_storage();
+        CscMatrix::new(p0.rows(), p0.cols(), t, y, u)
+    }
+
+    pub fn new(qubo: &Qubo) -> Self {
+        let q_new = Self::make_cb_form(&(qubo.q));
+        Self {
+            q: q_new,
+            c: qubo.c.clone(),
+        }
+    }
+}
+impl SubProblemSolver for ClarabelLPSolver {
+
+
+    fn solve_lower_bound(&self, bbsolver: &BBSolver, node: &QuboBBNode) -> SubProblemResult {
+
+        let mut settings = DefaultSettings {
+            verbose: false,
+            ..Default::default()
+        };
+
+        // this solves the glover's reformulation of the problem, e.g. the QUBO is transformed into a linear problem
+
+        settings.presolve_enable = true;
+
+        // first find the number of edges that we are dealing with in this qubo
+        let edges = &bbsolver.qubo.q.iter().filter(|(_, (i,j))| i < j).collect::<Vec<_>>();
+        let edge_weights = Array1::from(edges.iter().map(|&v| v.0));
+        let num_aux_vars = edge_weights.count();
+
+        let num_unfixed = bbsolver.qubo.num_x() - node.fixed_variables.len();
+
+        let P = CscMatrix::zeros((num_unfixed + num_aux_vars, num_unfixed + num_aux_vars));
+
+        !unimplemented!("This function is not implemented yet")
+    }
+}

--- a/src/subproblemsolvers/clarabel_qp.rs
+++ b/src/subproblemsolvers/clarabel_qp.rs
@@ -10,19 +10,12 @@ use crate::qubo::Qubo;
 use crate::branch_subproblem::SubProblemResult;
 
 #[derive(Clone)]
-pub struct ClarabelSubProblemSolver {
+pub struct ClarabelQPSolver {
     pub q: CscMatrix,
     pub c: Array1<f64>,
 }
 
-impl SubProblemSolver for ClarabelSubProblemSolver {
-    fn new(qubo: &Qubo) -> Self {
-        let q_new = Self::make_cb_form(&(qubo.q));
-        Self {
-            q: q_new,
-            c: qubo.c.clone(),
-        }
-    }
+impl SubProblemSolver for ClarabelQPSolver {
 
     fn solve_lower_bound(&self, bbsolver: &BBSolver, node: &QuboBBNode) -> SubProblemResult {
         // solve QP associated with the node
@@ -92,7 +85,14 @@ impl SubProblemSolver for ClarabelSubProblemSolver {
     }
 }
 
-impl ClarabelSubProblemSolver {
+impl ClarabelQPSolver {
+    pub fn new(qubo: &Qubo) -> Self {
+        let q_new = Self::make_cb_form(&(qubo.q));
+        Self {
+            q: q_new,
+            c: qubo.c.clone(),
+        }
+    }
     pub fn make_cb_form(p0: &CsMat<f64>) -> CscMatrix {
         let (t, y, u) = p0.to_csc().into_raw_storage();
         CscMatrix::new(p0.rows(), p0.cols(), t, y, u)
@@ -169,7 +169,7 @@ fn make_sub_problem(
 
 #[cfg(test)]
 mod tests {
-    use crate::subproblemsolvers::clarabel_qp::ClarabelSubProblemSolver;
+    use crate::subproblemsolvers::clarabel_qp::ClarabelQPSolver;
     use crate::qubo::Qubo;
     use crate::tests::make_solver_qubo;
     use ndarray::Array1;
@@ -182,7 +182,7 @@ mod tests {
 
         let qubo = make_solver_qubo();
 
-        let clarabel_matrix = ClarabelSubProblemSolver::make_cb_form(&qubo.q);
+        let clarabel_matrix = ClarabelQPSolver::make_cb_form(&qubo.q);
 
         // check the number of non-zero elements
         assert_eq!(qubo.q.nnz(), clarabel_matrix.nnz());

--- a/src/subproblemsolvers/clarabel_qp.rs
+++ b/src/subproblemsolvers/clarabel_qp.rs
@@ -26,12 +26,12 @@ impl SubProblemSolver for ClarabelQPSolver {
         };
 
         // find projected subproblem
-        let (trial_sub_qubo, unfixed_map, _constant) =
+        let (sub_qubo, unfixed_map, _constant) =
             make_sub_problem(&bbsolver.qubo, node.fixed_variables.clone());
 
-        let min_eig = trial_sub_qubo.hess_eigenvalues();
-        let min_eig = min_eig.iter().fold(f64::INFINITY, |acc, &x| x.min(acc));
-        let sub_qubo = trial_sub_qubo.make_diag_transform(0.0001 - min_eig);
+        // let min_eig = trial_sub_qubo.hess_eigenvalues();
+        // let min_eig = min_eig.iter().fold(f64::INFINITY, |acc, &x| x.min(acc));
+        // let sub_qubo = trial_sub_qubo.make_diag_transform(0.0001 - min_eig);
 
         // generate the constraint matrix
         let A_size = 2 * sub_qubo.num_x();


### PR DESCRIPTION
Basically we have been using only clarabel's qp solver to solve all sub problems (and have baked that into some of the code). Well it is time to look at LP and SDP sub problems, and paves the way to add custom solvers ect in the far future.

The general arc of this will be to implement a subsolver for the LP relaxation of the MILP glover reformulation (e.g. linearize all the cross terms then relax it). 