### PR TITLE
the union of a log of different improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hercules"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Dustin Kenefake"]
 license = "BSD-3-Clause"

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -72,6 +72,7 @@ pub fn make_bench_data() -> BenchData {
         lower_bound: f64::NEG_INFINITY,
         solution: 0.5 * Array1::ones(process_solver.qubo.num_x()),
         fixed_variables: process_solver.options.fixed_variables.clone(),
+        run_heuristic: false,
     };
 
     BenchData {

--- a/src/branch_node.rs
+++ b/src/branch_node.rs
@@ -8,6 +8,7 @@ pub struct QuboBBNode {
     pub lower_bound: f64,
     pub solution: Array1<f64>,
     pub fixed_variables: FixedVarMap,
+    pub run_heuristic: bool,
 }
 
 impl Eq for QuboBBNode {}

--- a/src/branch_stratagy.rs
+++ b/src/branch_stratagy.rs
@@ -651,6 +651,29 @@ pub fn moving_edges(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
     }
 }
 
+/// A fun branching strategy that pseudo randomly picks one of the cheaper branching strategies
+/// to use at each node at (pesudo) random
+/// # Panics
+/// if the node does not have an unfixed variable
+pub fn round_robin(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
+    // fun branching strat based on pseudo randomly picking a decent (and cheap branching strat)
+
+    // make a random seed that is unique to each node
+    let node_seed = node.fixed_variables.keys().sum::<usize>() as u64;
+    let solver_seed = solver.options.seed as u64 + solver.nodes_solved as u64;
+
+    let mut prng = PRNG {
+        generator: JsfLarge::from(node_seed + solver_seed),
+    };
+
+    match prng.gen_u64() % 3 {
+        0 => largest_edges(solver, node),
+        1 => most_edges(solver, node),
+        2 => worst_approximation(solver, node),
+        _ => panic!("Random branch selection failed"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{connected_components, worst_approximation_second_order};
@@ -702,28 +725,5 @@ mod tests {
 
         let result = worst_approximation_second_order(&solver, &node);
         assert_eq!(result.branch_variable, 1);
-    }
-}
-
-/// A fun branching strategy that pseudo randomly picks one of the cheaper branching strategies
-/// to use at each node at (pesudo) random
-/// # Panics
-/// if the node does not have an unfixed variable
-pub fn round_robin(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
-    // fun branching strat based on pseudo randomly picking a decent (and cheap branching strat)
-
-    // make a random seed that is unique to each node
-    let node_seed = node.fixed_variables.keys().sum::<usize>() as u64;
-    let solver_seed = solver.options.seed as u64 + solver.nodes_solved as u64;
-
-    let mut prng = PRNG {
-        generator: JsfLarge::from(node_seed + solver_seed),
-    };
-
-    match prng.gen_u64() % 3 {
-        0 => largest_edges(solver, node),
-        1 => most_edges(solver, node),
-        2 => worst_approximation(solver, node),
-        _ => panic!("Random branch selection failed"),
     }
 }

--- a/src/branch_stratagy.rs
+++ b/src/branch_stratagy.rs
@@ -28,6 +28,12 @@ pub struct BranchResult {
     pub found_fixed_vars: FixedVarMap,
 }
 
+fn first_unfixed_variable(solver: &BBSolver, node: &QuboBBNode) -> usize {
+    (0..solver.qubo.num_x())
+        .find(|i| !node.fixed_variables.contains_key(i))
+        .expect("No variable to branch on")
+}
+
 impl BranchStrategy {
     /// # Panics
     /// if the node does not have an unfixed variable or if the branching strategy fails
@@ -63,7 +69,7 @@ impl BranchStrategy {
 }
 
 fn connected_components(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
-    let mut selected_variable = 0;
+    let mut selected_variable = first_unfixed_variable(solver, node);
     let mut max_components = 0;
     // scan through the variables and find the variable that breaks the graph into the most components
     for i in 0..solver.qubo.num_x() {
@@ -109,7 +115,7 @@ fn most_edges(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
 
     // find the variable with the most edges (fixed variables in the node are not counted)
     let mut max_edges = 0;
-    let mut index_max_edges = 0;
+    let mut index_max_edges = first_unfixed_variable(solver, node);
 
     for i in 0..solver.qubo.num_x() {
         if !node.fixed_variables.contains_key(&i) && edge_count[i] > max_edges {
@@ -148,7 +154,7 @@ fn largest_edges(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
 
     // find the variable with the most edges (fixed variables in the node are not counted)
     let mut min_edge_value = 0.0;
-    let mut index_max_edges = 0;
+    let mut index_max_edges = first_unfixed_variable(solver, node);
 
     for i in 0..solver.qubo.num_x() {
         if !node.fixed_variables.contains_key(&i) && edge_count[i] > min_edge_value {
@@ -166,7 +172,7 @@ fn largest_edges(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
 /// Computes what branch will generate the most fixed variables via the preprocesser
 pub fn most_fixed(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
     let mut most_fixed = 0;
-    let mut branch_variable = 0;
+    let mut branch_variable = first_unfixed_variable(solver, node);
 
     let mut found_fixed_vars = FixedVarMap::default();
 
@@ -232,7 +238,7 @@ pub fn first_not_fixed(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
 pub fn largest_diag(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
     // find the variable with the largest diagonal value in the Q matrix
     let mut max_diag = f64::NEG_INFINITY;
-    let mut index_max_diag = 0;
+    let mut index_max_diag = first_unfixed_variable(solver, node);
 
     for i in 0..solver.qubo.num_x() {
         if !node.fixed_variables.contains_key(&i) {
@@ -253,7 +259,7 @@ pub fn largest_diag(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
 
 pub fn most_violated(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
     let mut most_violated = 1.0;
-    let mut index_most_violated = 0;
+    let mut index_most_violated = first_unfixed_variable(solver, node);
 
     for i in 0..solver.qubo.num_x() {
         if !node.fixed_variables.contains_key(&i) {
@@ -277,7 +283,7 @@ pub fn worst_approximation_second_order(solver: &BBSolver, node: &QuboBBNode) ->
 
     // tracking variables for the worst approximation
     let mut worst_approximation = f64::NEG_INFINITY;
-    let mut index_worst_approximation = 0;
+    let mut index_worst_approximation = first_unfixed_variable(solver, node);
 
     // scan through the edges of the Q matrix and find the worst gain
 
@@ -359,12 +365,14 @@ pub fn full_strong_branching(solver: &BBSolver, node: &QuboBBNode) -> BranchResu
             lower_bound: 0.0,
             fixed_variables: list_0,
             solution: node.solution.clone(),
+            run_heuristic: false,
         };
 
         let node_1 = QuboBBNode {
             lower_bound: 0.0,
             fixed_variables: list_1,
             solution: node.solution.clone(),
+            run_heuristic: false,
         };
 
         // solve for the
@@ -466,12 +474,14 @@ pub fn partial_strong_branching(solver: &BBSolver, node: &QuboBBNode) -> BranchR
             lower_bound: 0.0,
             fixed_variables: list_0,
             solution: node.solution.clone(),
+            run_heuristic: false,
         };
 
         let node_1 = QuboBBNode {
             lower_bound: 0.0,
             fixed_variables: list_1,
             solution: node.solution.clone(),
+            run_heuristic: false,
         };
 
         let bound_0 = solver
@@ -559,7 +569,7 @@ pub fn worst_approximation(solver: &BBSolver, node: &QuboBBNode) -> BranchResult
 
     // tracking variables for the worst approximation
     let mut worst_approximation = f64::NEG_INFINITY;
-    let mut index_worst_approximation = 0;
+    let mut index_worst_approximation = first_unfixed_variable(solver, node);
 
     // scan through the variables and find the worst gain
     for i in 0..solver.qubo.num_x() {
@@ -623,7 +633,7 @@ pub fn moving_edges(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
 
     // find the variable with the most edges (fixed variables in the node are not counted)
     let mut min_edge_value = -10.0;
-    let mut index_max_edges = 0;
+    let mut index_max_edges = first_unfixed_variable(solver, node);
 
     for i in 0..solver.qubo.num_x() {
         if !node.fixed_variables.contains_key(&i) {
@@ -638,6 +648,60 @@ pub fn moving_edges(solver: &BBSolver, node: &QuboBBNode) -> BranchResult {
     BranchResult {
         branch_variable: index_max_edges,
         found_fixed_vars: FixedVarMap::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{connected_components, worst_approximation_second_order};
+    use crate::branch_node::QuboBBNode;
+    use crate::branchbound::BBSolver;
+    use crate::qubo::Qubo;
+    use crate::solver_options::SolverOptions;
+    use crate::FixedVarMap;
+    use ndarray::Array1;
+    use sprs::CsMat;
+
+    fn make_solver(qubo: Qubo) -> BBSolver {
+        let mut options = SolverOptions::new();
+        options.verbose = 0;
+        options.threads = 1;
+        BBSolver::new(qubo, options)
+    }
+
+    #[test]
+    fn connected_components_falls_back_to_first_unfixed() {
+        let qubo = Qubo::new(CsMat::<f64>::zero((3, 3)));
+        let solver = make_solver(qubo);
+        let mut fixed_variables = FixedVarMap::default();
+        fixed_variables.insert(0, 0);
+        fixed_variables.insert(1, 1);
+        let node = QuboBBNode {
+            lower_bound: 0.0,
+            solution: 0.5 * Array1::ones(3),
+            fixed_variables,
+            run_heuristic: false,
+        };
+
+        let result = connected_components(&solver, &node);
+        assert_eq!(result.branch_variable, 2);
+    }
+
+    #[test]
+    fn worst_approximation_second_order_falls_back_to_first_unfixed_without_edges() {
+        let qubo = Qubo::new(CsMat::<f64>::zero((3, 3)));
+        let solver = make_solver(qubo);
+        let mut fixed_variables = FixedVarMap::default();
+        fixed_variables.insert(0, 1);
+        let node = QuboBBNode {
+            lower_bound: 0.0,
+            solution: 0.5 * Array1::ones(3),
+            fixed_variables,
+            run_heuristic: false,
+        };
+
+        let result = worst_approximation_second_order(&solver, &node);
+        assert_eq!(result.branch_variable, 1);
     }
 }
 

--- a/src/branchbound.rs
+++ b/src/branchbound.rs
@@ -62,6 +62,12 @@ pub enum SolverResult {
 const ROOT_PROBE_LIMIT: usize = 25;
 
 impl BBSolver {
+    fn lower_bound_prunes(&self, lower_bound: f64) -> bool {
+        let scale = self.best_solution_value.abs().max(1.0);
+        let tol = 1e-10 * scale;
+        lower_bound >= self.best_solution_value - tol
+    }
+
     /// Creates a new B&B solver
     pub fn new(qubo: Qubo, options: SolverOptions) -> Self {
         let qubo = qubo.convex_symmetric_form();
@@ -105,16 +111,7 @@ impl BBSolver {
         let mut fixed_variables =
             preprocess_with_prepared(&self.prepared_preprocess, &self.options.fixed_variables);
 
-        if matches!(self.options.node_lower_bound, NodeLowerBoundSelection::RoofDual) {
-            let roof_result = iterative_roof_duality_presolve(
-                &self.qubo_pp_form,
-                &fixed_variables,
-                self.qubo.num_x(),
-            );
-            for (index, value) in roof_result.fixed_variables {
-                fixed_variables.insert(index, value);
-            }
-        }
+        let root_bound = self.apply_node_lower_bound(&mut fixed_variables);
 
         let (probe_constraints, _) =
             probe_limited(&self.qubo_pp_form, &fixed_variables, true, ROOT_PROBE_LIMIT);
@@ -123,14 +120,15 @@ impl BBSolver {
 
         // create the root node
         let mut root_node = QuboBBNode {
-            lower_bound: f64::NEG_INFINITY,
+            lower_bound: root_bound,
             solution: 0.5 * Array1::ones(self.qubo.num_x()), // initial guess is 0.5 for all variables
             fixed_variables,
+            run_heuristic: true,
         };
 
         // solve the root node subproblem
         let (root_lower_bound, root_solution) = self.solve_node(&root_node);
-        root_node.lower_bound = root_lower_bound;
+        root_node.lower_bound = root_node.lower_bound.max(root_lower_bound);
         root_node.solution = root_solution;
 
         // add the root node to the list of nodes
@@ -184,7 +182,7 @@ impl BBSolver {
         }
 
         // if our parent solution is above our current feasible soltion then prune
-        if node.lower_bound > self.best_solution_value {
+        if self.lower_bound_prunes(node.lower_bound) {
             return (PruneAction::Prune, None);
         }
 
@@ -244,20 +242,7 @@ impl BBSolver {
         // pass to the presolver to see if there are any variables we can fix
         node.fixed_variables = self.preprocess_fixed_variables(&node.fixed_variables);
 
-        let node_bound = match self.options.node_lower_bound {
-            NodeLowerBoundSelection::Li => li_lower_bound(&self.qubo, &node.fixed_variables),
-            NodeLowerBoundSelection::RoofDual => {
-                let roof_result = iterative_roof_duality_presolve(
-                    &self.qubo_pp_form,
-                    &node.fixed_variables,
-                    self.qubo.num_x(),
-                );
-                for (index, value) in roof_result.fixed_variables {
-                    node.fixed_variables.insert(index, value);
-                }
-                roof_result.lower_bound.unwrap_or(f64::NEG_INFINITY)
-            }
-        };
+        let node_bound = self.apply_node_lower_bound(&mut node.fixed_variables);
         node.lower_bound = node.lower_bound.max(node_bound);
 
         // with this expanded set, can we prune the node?
@@ -291,6 +276,7 @@ impl BBSolver {
 
         // We now need to solve the node to generate the lower bound and solution
         let (lower_bound, solution) = self.solve_node(&node);
+        let lower_bound = lower_bound.max(node.lower_bound);
 
         // inject the solution back into the node
         node.solution.clone_from(&solution);
@@ -321,8 +307,8 @@ impl BBSolver {
             };
         }
 
-        let best_update = self
-            .should_run_heuristic(&node)
+        let best_update = node
+            .run_heuristic
             .then(|| self.options.heuristic.make_heuristic(self, &node));
 
         // generate the branches
@@ -343,10 +329,10 @@ impl BBSolver {
 
         if let Some((zero_branch, one_branch)) = state.branches {
             // only add the branches if their lower bound is better than the current best solution
-            if zero_branch.lower_bound <= self.best_solution_value {
+            if !self.lower_bound_prunes(zero_branch.lower_bound) {
                 self.nodes.push(zero_branch);
             }
-            if one_branch.lower_bound <= self.best_solution_value {
+            if !self.lower_bound_prunes(one_branch.lower_bound) {
                 self.nodes.push(one_branch);
             }
         }
@@ -359,6 +345,8 @@ impl BBSolver {
         if solution_value < self.best_solution_value {
             self.best_solution.clone_from(solution);
             self.best_solution_value = solution_value;
+            let best_solution_value = self.best_solution_value;
+            let tol = 1e-10 * best_solution_value.abs().max(1.0);
 
             // if we have an early stopping condition, then we can check if we have a solution
             // let beck_proof = beck_proof(&self.qubo, &self.best_solution);
@@ -372,7 +360,7 @@ impl BBSolver {
             // We can remove all nodes that are worse than the current best solution
             self.nodes.retain(|node| {
                 // if the node's lower bound is worse than the best solution, we can prune it
-                node.lower_bound <= self.best_solution_value
+                node.lower_bound < best_solution_value - tol
             });
         }
     }
@@ -384,10 +372,11 @@ impl BBSolver {
             let optional_node = self.nodes.pop();
 
             // check and unwrap the node if it is safe
-            let node = optional_node?;
+            let mut node = optional_node?;
 
             // we increment the number of nodes we have visited
             self.apply_logging_action(NodeLoggingAction::Visited);
+            node.run_heuristic |= self.nodes_visited % 31 == 0;
 
             // if we can't prune it, then we return it
             let (prune, best_update) = self.can_prune_action(&node);
@@ -452,12 +441,6 @@ impl BBSolver {
         self.branch_strategy.make_branch(self, node)
     }
 
-    fn should_run_heuristic(&self, node: &QuboBBNode) -> bool {
-        // Heuristics are most useful earlier in the tree when they can improve the incumbent
-        // before a lot of nodes have been generated.
-        node.fixed_variables.len() * 2 <= self.qubo.num_x()
-    }
-
     /// Actually branches the node into two new nodes
     pub fn branch(
         node: QuboBBNode,
@@ -473,6 +456,8 @@ impl BBSolver {
         // add fixed variables
         zero_branch.fixed_variables.insert(branch_id, 0);
         one_branch.fixed_variables.insert(branch_id, 1);
+        zero_branch.run_heuristic = false;
+        one_branch.run_heuristic = false;
 
         // update the solution and lower bound for the new nodes
         zero_branch.solution.clone_from(&solution);
@@ -494,6 +479,23 @@ impl BBSolver {
         fixed_variables: &FixedVarMap,
     ) -> FixedVarMap {
         preprocess_with_prepared(&self.prepared_preprocess, fixed_variables)
+    }
+
+    fn apply_node_lower_bound(&self, fixed_variables: &mut FixedVarMap) -> f64 {
+        match self.options.node_lower_bound {
+            NodeLowerBoundSelection::Li => li_lower_bound(&self.qubo, fixed_variables),
+            NodeLowerBoundSelection::RoofDual => {
+                let roof_result = iterative_roof_duality_presolve(
+                    &self.qubo_pp_form,
+                    fixed_variables,
+                    self.qubo.num_x(),
+                );
+                for (index, value) in roof_result.fixed_variables {
+                    fixed_variables.insert(index, value);
+                }
+                roof_result.lower_bound.unwrap_or(f64::NEG_INFINITY)
+            }
+        }
     }
 }
 
@@ -531,6 +533,22 @@ mod tests {
         solver.solve();
 
         assert_eq!(solver.best_solution, Array1::from_vec(vec![1, 1, 1]));
+    }
+
+    #[test]
+    fn root_node_preserves_heuristic_flag_on_first_pop() {
+        let p = Qubo::new(CsMat::eye(2));
+        let mut solver = branchbound::BBSolver::new(p, SolverOptions::new());
+
+        solver.nodes.push(crate::branch_node::QuboBBNode {
+            lower_bound: f64::NEG_INFINITY,
+            solution: 0.5 * Array1::ones(2),
+            fixed_variables: HashMap::default(),
+            run_heuristic: true,
+        });
+
+        let node = solver.get_next_node().expect("expected root node");
+        assert!(node.run_heuristic);
     }
 
     #[test]

--- a/src/branchbound.rs
+++ b/src/branchbound.rs
@@ -376,7 +376,7 @@ impl BBSolver {
 
             // we increment the number of nodes we have visited
             self.apply_logging_action(NodeLoggingAction::Visited);
-            node.run_heuristic |= self.nodes_visited % 31 == 0;
+            node.run_heuristic |= self.nodes_visited.is_multiple_of(31);
 
             // if we can't prune it, then we return it
             let (prune, best_update) = self.can_prune_action(&node);
@@ -643,28 +643,28 @@ mod tests {
 
         for branch in &branch_options {
             for sup_problem_solver in &sub_problem_solvers {
-                setup_and_solve_problem(branch, &sup_problem_solver, qubo, sol_val);
+                setup_and_solve_problem(*branch, *sup_problem_solver, qubo, sol_val);
             }
         }
     }
 
     pub fn setup_and_solve_problem(
-        branch: &BranchStrategy,
-        sup_problem_solver: &SubProblemSelection,
+        branch: BranchStrategy,
+        sup_problem_solver: SubProblemSelection,
         qubo: &Qubo,
         true_sol: &Array1<usize>,
     ) {
         let mut prng = make_test_prng();
 
-        let fixed_variables = preprocess_qubo(&qubo, &HashMap::default(), false);
+        let fixed_variables = preprocess_qubo(qubo, &HashMap::default(), false);
 
-        let guess = local_search::particle_swarm_search(&qubo, 10, 100, &mut prng);
+        let guess = local_search::particle_swarm_search(qubo, 10, 100, &mut prng);
 
         let mut options = get_default_solver_options();
 
-        options.branch_strategy = *branch;
-        options.fixed_variables = fixed_variables.clone();
-        options.sub_problem_solver = *sup_problem_solver;
+        options.branch_strategy = branch;
+        options.fixed_variables = fixed_variables;
+        options.sub_problem_solver = sup_problem_solver;
         options.verbose = 0;
 
         let mut solver = branchbound::BBSolver::new(qubo.clone(), options);
@@ -673,7 +673,7 @@ mod tests {
 
         let (_, sol_value) = solver.solve();
 
-        let actual_obj = solver.qubo.eval_usize(&true_sol);
+        let actual_obj = solver.qubo.eval_usize(true_sol);
 
         // the solution should be within 1E-5 of the actual solution
         // we don't check against the solution as there can be multiple optimal solutions

--- a/src/graph_utils.rs
+++ b/src/graph_utils.rs
@@ -8,9 +8,22 @@ pub fn get_all_disconnected_graphs(
     qubo: &Qubo,
     fixed_vars: &FixedVarMap,
 ) -> Vec<Vec<usize>> {
+    get_all_disconnected_graphs_with_extra(qubo, fixed_vars, None)
+}
+
+pub fn get_all_disconnected_graphs_with_extra(
+    qubo: &Qubo,
+    fixed_vars: &FixedVarMap,
+    extra_fixed_vars: Option<&FixedVarMap>,
+) -> Vec<Vec<usize>> {
     let mut visited = vec![false; qubo.num_x()];
     for &fixed in fixed_vars.keys() {
         visited[fixed] = true;
+    }
+    if let Some(extra_fixed_vars) = extra_fixed_vars {
+        for &fixed in extra_fixed_vars.keys() {
+            visited[fixed] = true;
+        }
     }
 
     let mut output = Vec::new();

--- a/src/heuristic_stratagy.rs
+++ b/src/heuristic_stratagy.rs
@@ -10,7 +10,7 @@ pub enum HeuristicSelection {
 }
 
 impl HeuristicSelection {
-    pub fn make_heuristic(&self, solver: &BBSolver, node: &QuboBBNode) -> (Array1<usize>, f64) {
+    pub fn make_heuristic(self, solver: &BBSolver, node: &QuboBBNode) -> (Array1<usize>, f64) {
         match self {
             Self::SimpleRounding => Self::simple_rounding(solver, node),
             Self::LocalSearch => Self::local_search(solver, node),

--- a/src/heuristic_stratagy.rs
+++ b/src/heuristic_stratagy.rs
@@ -28,22 +28,7 @@ impl HeuristicSelection {
     pub fn local_search(solver: &BBSolver, node: &QuboBBNode) -> (Array1<usize>, f64) {
         // round the solution to the nearest integer
         let rounded_solution = utils::rounded_vector(&node.solution);
-
-        let mut x = rounded_solution;
-
-        let mut x_1 = local_search_utils::two_step_local_search_improved(&solver.qubo, &x);
-
-        let mut steps = 0;
-
-        while x_1 != x && steps < 100 {
-            x.clone_from(&x_1);
-            x_1 = local_search_utils::two_step_local_search_improved(&solver.qubo, &x);
-            steps += 1;
-        }
-
-        let objective = solver.qubo.eval_usize(&x_1);
-
-        (x_1, objective)
+        local_search_utils::two_step_local_search_descent_all(&solver.qubo, &rounded_solution, 100)
     }
 }
 
@@ -83,6 +68,7 @@ mod tests {
                 lower_bound: f64::NEG_INFINITY,
                 solution: x_0.clone(),
                 fixed_variables: FixedVarMap::default(),
+                run_heuristic: false,
             };
 
             // compute the next step
@@ -115,6 +101,7 @@ mod tests {
                 lower_bound: f64::NEG_INFINITY,
                 solution: x_0.clone(),
                 fixed_variables: FixedVarMap::default(),
+                run_heuristic: false,
             };
 
             let rounded_sol = utils::rounded_vector(&x_0);
@@ -130,4 +117,5 @@ mod tests {
             assert!(obj_1 <= obj_0);
         }
     }
+
 }

--- a/src/local_search.rs
+++ b/src/local_search.rs
@@ -39,19 +39,7 @@ use smolprng::{Algorithm, PRNG};
 /// let x_sol = local_search::simple_local_search(&p, &x_0, 1000);
 /// ```
 pub fn simple_local_search(qubo: &Qubo, x_0: &Array1<usize>, max_steps: usize) -> Array1<usize> {
-    let mut x = x_0.clone();
-    let variables: Vec<usize> = (0..qubo.num_x()).collect();
-    let mut x_1 = local_search_utils::one_step_local_search_improved(qubo, &x, &variables);
-    let mut steps = 0;
-
-    while x_1 != x && steps <= max_steps {
-        x.clone_from(&x_1);
-        // apply the local search to the selected variables
-        x_1 = local_search_utils::one_step_local_search_improved(qubo, &x, &variables);
-        steps += 1;
-    }
-
-    x_1
+    local_search_utils::two_step_local_search_descent_all(qubo, x_0, max_steps).0
 }
 
 /// Given a QUBO and a vector of initial points, run local searches on each initial point and return all of the solutions.

--- a/src/local_search_utils.rs
+++ b/src/local_search_utils.rs
@@ -9,6 +9,25 @@
 use crate::qubo::Qubo;
 use ndarray::Array1;
 
+fn one_flip_delta_from_gradient(qubo: &Qubo, x: &Array1<usize>, grad: &Array1<f64>, i: usize) -> f64 {
+    let q_ii = *qubo.q.get(i, i).unwrap_or(&0.0);
+    (1.0 - 2.0 * x[i] as f64) * grad[i] + 0.5 * q_ii
+}
+
+fn update_gradient_for_flip(qubo: &Qubo, grad: &mut Array1<f64>, index: usize, alpha: f64) {
+    if let Some(row) = qubo.q.outer_view(index) {
+        for (j, value) in row.iter() {
+            grad[j] += 0.5 * alpha * value;
+        }
+    }
+
+    if let Some(col) = qubo.q.transpose_view().outer_view(index) {
+        for (j, value) in col.iter() {
+            grad[j] += 0.5 * alpha * value;
+        }
+    }
+}
+
 /// Performs a single step of local search, which is to say that it will flip a single bit and return the best solution out of all
 /// of the possible bit flips.
 /// This takes O(|Q|) + O(n) time, where |Q| is the number of non-zero elements in the QUBO matrix.
@@ -71,53 +90,144 @@ pub fn one_step_local_search_improved(
     }
 }
 
-/// Performs a two-step local search, which is to say that it will flip either one or two bits and
-/// return the best solution out of all the possible bit flips.
-/// This takes O(|Q|) + O(n) time, where |Q| is the number of non-zero elements in the QUBO matrix.
-/// # Panics
-/// Will panic if the QUBO has no variables.
-pub fn two_step_local_search_improved(qubo: &Qubo, x_0: &Array1<usize>) -> Array1<usize> {
-    // Do a neighborhood search of up to two bit flips and returns the best solution
-    let (_, obj_1d) = one_flip_objective(qubo, x_0);
+/// Performs repeated one- and two-bit local search moves while maintaining the gradient
+/// incrementally after accepted flips.
+///
+/// This is intended for the heuristic path where we want to avoid rebuilding the full
+/// one-flip objective state from scratch after every move.
+pub fn two_step_local_search_descent(
+    qubo: &Qubo,
+    x_0: &Array1<usize>,
+    selected_vars: &[usize],
+    max_steps: usize,
+) -> (Array1<usize>, f64) {
+    let mut x = x_0.clone();
+    let mut grad = qubo.eval_grad_usize(&x);
 
-    let best_1d_neighbor = obj_1d
-        .iter()
-        .enumerate()
-        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-        .unwrap()
-        .0;
+    let mut selected = vec![false; qubo.num_x()];
+    for &i in selected_vars {
+        selected[i] = true;
+    }
 
-    let best_obj_1d = obj_1d[best_1d_neighbor];
+    for _ in 0..max_steps {
+        let mut best_obj_1d = f64::INFINITY;
+        let mut best_1d_neighbor = None;
+        let mut one_flip_delta = Array1::<f64>::from_elem(qubo.num_x(), f64::INFINITY);
 
-    let mut best_obj_2d = f64::INFINITY;
-    let mut best_2d_neighbor = (0, 1);
+        for &i in selected_vars {
+            let delta = one_flip_delta_from_gradient(qubo, &x, &grad, i);
+            one_flip_delta[i] = delta;
 
-    for (q_ij, (i, j)) in &qubo.q {
-        if i > j {
-            let current_obj_2d = obj_1d[i]
-                + obj_1d[j]
-                + q_ij * (1.0 - 2.0 * (x_0[i] as f64)) * (1.0 - 2.0 * (x_0[j] as f64));
+            if delta < best_obj_1d {
+                best_obj_1d = delta;
+                best_1d_neighbor = Some(i);
+            }
+        }
+
+        let mut best_obj_2d = f64::INFINITY;
+        let mut best_2d_neighbor = None;
+
+        for (&q_ij, (i, j)) in &qubo.q {
+            if i <= j || !selected[i] || !selected[j] {
+                continue;
+            }
+
+            let current_obj_2d = one_flip_delta[i]
+                + one_flip_delta[j]
+                + q_ij * (1.0 - 2.0 * x[i] as f64) * (1.0 - 2.0 * x[j] as f64);
+
+            if current_obj_2d < best_obj_2d {
+                best_obj_2d = current_obj_2d;
+                best_2d_neighbor = Some((i, j));
+            }
+        }
+
+        if best_obj_2d < best_obj_1d && best_obj_2d < 0.0 {
+            let (i, j) = best_2d_neighbor.expect("best two-flip move should exist");
+            let alpha_i = 1.0 - 2.0 * x[i] as f64;
+            let alpha_j = 1.0 - 2.0 * x[j] as f64;
+            update_gradient_for_flip(qubo, &mut grad, i, alpha_i);
+            update_gradient_for_flip(qubo, &mut grad, j, alpha_j);
+            x[i] = 1 - x[i];
+            x[j] = 1 - x[j];
+        } else if best_obj_1d < 0.0 {
+            let i = best_1d_neighbor.expect("best one-flip move should exist");
+            let alpha = 1.0 - 2.0 * x[i] as f64;
+            update_gradient_for_flip(qubo, &mut grad, i, alpha);
+            x[i] = 1 - x[i];
+        } else {
+            break;
+        }
+    }
+
+    let objective = qubo.eval_usize(&x);
+    (x, objective)
+}
+
+/// Specialized version of `two_step_local_search_descent` for the common case where all
+/// variables are eligible. This avoids building the selected-variable bitmap and the temporary
+/// dense delta array used by the subset variant.
+pub fn two_step_local_search_descent_all(
+    qubo: &Qubo,
+    x_0: &Array1<usize>,
+    max_steps: usize,
+) -> (Array1<usize>, f64) {
+    let mut x = x_0.clone();
+    let mut grad = qubo.eval_grad_usize(&x);
+    let n = qubo.num_x();
+    let mut one_flip_delta = vec![0.0; n];
+
+    for _ in 0..max_steps {
+        let mut best_obj_1d = f64::INFINITY;
+        let mut best_1d_neighbor = 0usize;
+
+        for i in 0..n {
+            let delta = one_flip_delta_from_gradient(qubo, &x, &grad, i);
+            one_flip_delta[i] = delta;
+
+            if delta < best_obj_1d {
+                best_obj_1d = delta;
+                best_1d_neighbor = i;
+            }
+        }
+
+        let mut best_obj_2d = f64::INFINITY;
+        let mut best_2d_neighbor = (0usize, 0usize);
+
+        for (&q_ij, (i, j)) in &qubo.q {
+            if i <= j {
+                continue;
+            }
+
+            let current_obj_2d = one_flip_delta[i]
+                + one_flip_delta[j]
+                + q_ij * (1.0 - 2.0 * x[i] as f64) * (1.0 - 2.0 * x[j] as f64);
 
             if current_obj_2d < best_obj_2d {
                 best_obj_2d = current_obj_2d;
                 best_2d_neighbor = (i, j);
             }
         }
+
+        if best_obj_2d < best_obj_1d && best_obj_2d < 0.0 {
+            let (i, j) = best_2d_neighbor;
+            let alpha_i = 1.0 - 2.0 * x[i] as f64;
+            let alpha_j = 1.0 - 2.0 * x[j] as f64;
+            update_gradient_for_flip(qubo, &mut grad, i, alpha_i);
+            update_gradient_for_flip(qubo, &mut grad, j, alpha_j);
+            x[i] = 1 - x[i];
+            x[j] = 1 - x[j];
+        } else if best_obj_1d < 0.0 {
+            let alpha = 1.0 - 2.0 * x[best_1d_neighbor] as f64;
+            update_gradient_for_flip(qubo, &mut grad, best_1d_neighbor, alpha);
+            x[best_1d_neighbor] = 1 - x[best_1d_neighbor];
+        } else {
+            break;
+        }
     }
 
-    // see if the best 2d neighbor is better than the best 1d neighbor
-    if best_obj_2d < best_obj_1d && best_obj_2d < 0.0f64 {
-        let mut x_1 = x_0.clone();
-        x_1[best_2d_neighbor.0] = 1 - x_1[best_2d_neighbor.0];
-        x_1[best_2d_neighbor.1] = 1 - x_1[best_2d_neighbor.1];
-        x_1
-    } else if best_obj_1d < 0.0f64 {
-        let mut x_1 = x_0.clone();
-        x_1[best_1d_neighbor] = 1 - x_1[best_1d_neighbor];
-        x_1
-    } else {
-        x_0.clone()
-    }
+    let objective = qubo.eval_usize(&x);
+    (x, objective)
 }
 
 /// Auxiliary function to calculate the gains from flipping each variable
@@ -247,7 +357,8 @@ pub fn contract_point(
 mod tests {
 
     use crate::local_search_utils::{
-        one_step_local_search_improved, two_step_local_search_improved,
+        one_step_local_search_improved, two_step_local_search_descent,
+        two_step_local_search_descent_all,
     };
     use crate::qubo::Qubo;
     use smolprng::{JsfLarge, PRNG};
@@ -280,8 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn test_two_step_local_search_improved() {
-        // generate a random QUBO
+    fn test_two_step_local_search_descent() {
         let mut prng = PRNG {
             generator: JsfLarge::default(),
         };
@@ -290,24 +400,36 @@ mod tests {
         let selected_vars: Vec<usize> = (0..p.num_x()).collect();
 
         for _ in 0..100 {
-            // generate a random point inside with x in {0, 1}^10 with
             let x_0 =
                 crate::initial_points::generate_random_binary_point(p.num_x(), &mut prng, 0.5);
 
-            // compute the next step
-            let x_1 = one_step_local_search_improved(&p, &x_0, &selected_vars);
-            let x_2 = two_step_local_search_improved(&p, &x_0);
-
-            // compute the objective function values
             let obj_0 = p.eval_usize(&x_0);
-            let obj_1 = p.eval_usize(&x_1);
-            let obj_2 = p.eval_usize(&x_2);
+            let (x_1, obj_1) = two_step_local_search_descent(&p, &x_0, &selected_vars, 100);
+            let obj_eval = p.eval_usize(&x_1);
 
-            // ensure that two step local search is at least as good as one step local search
-            assert!(obj_2 <= obj_1);
-
-            // ensure that the objective has not increased
             assert!(obj_1 <= obj_0);
+            assert!((obj_1 - obj_eval).abs() < 1e-8);
+        }
+    }
+
+    #[test]
+    fn test_two_step_local_search_descent_all() {
+        let mut prng = PRNG {
+            generator: JsfLarge::default(),
+        };
+
+        let p = Qubo::make_random_qubo(50, &mut prng, 0.2);
+
+        for _ in 0..100 {
+            let x_0 =
+                crate::initial_points::generate_random_binary_point(p.num_x(), &mut prng, 0.5);
+
+            let obj_0 = p.eval_usize(&x_0);
+            let (x_1, obj_1) = two_step_local_search_descent_all(&p, &x_0, 100);
+            let obj_eval = p.eval_usize(&x_1);
+
+            assert!(obj_1 <= obj_0);
+            assert!((obj_1 - obj_eval).abs() < 1e-8);
         }
     }
 }

--- a/src/local_search_utils.rs
+++ b/src/local_search_utils.rs
@@ -181,9 +181,9 @@ pub fn two_step_local_search_descent_all(
         let mut best_obj_1d = f64::INFINITY;
         let mut best_1d_neighbor = 0usize;
 
-        for i in 0..n {
+        for (i, delta_slot) in one_flip_delta.iter_mut().enumerate().take(n) {
             let delta = one_flip_delta_from_gradient(qubo, &x, &grad, i);
-            one_flip_delta[i] = delta;
+            *delta_slot = delta;
 
             if delta < best_obj_1d {
                 best_obj_1d = delta;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -61,7 +61,7 @@ fn propagate_persistent_in_place(
     for (&index, &value) in persistent.iter() {
         fixed_values[index] = Some(value as u8);
     }
-    for (&index, &value) in extra_fixed.iter() {
+    for (&index, &value) in extra_fixed {
         fixed_values[index] = Some(value as u8);
     }
 

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,5 +1,5 @@
 use crate::FixedVarMap;
-use crate::preprocess::solve_small_components;
+use crate::preprocess::solve_small_components_in_place_with_extra;
 use crate::qubo::Qubo;
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -14,47 +14,54 @@ pub fn compute_iterative_persistence(
     iter_lim: usize,
 ) -> FixedVarMap {
     let adjacency = build_gradient_adjacency(qubo);
-    compute_iterative_persistence_with_adjacency(qubo, persistent, iter_lim, &adjacency)
+    compute_iterative_persistence_with_adjacency(
+        qubo,
+        persistent.clone(),
+        &FixedVarMap::default(),
+        iter_lim,
+        &adjacency,
+    )
 }
 
 pub(crate) fn compute_iterative_persistence_with_adjacency(
     qubo: &Qubo,
-    persistent: &FixedVarMap,
+    mut persistent: FixedVarMap,
+    extra_fixed: &FixedVarMap,
     iter_lim: usize,
     adjacency: &GradientAdjacency,
 ) -> FixedVarMap {
-    let mut new_persistent = persistent.clone();
     let iters = min(iter_lim, qubo.num_x());
 
     for _ in 0..iters {
-        let previous_len = new_persistent.len();
-        let incoming_persistent = propagate_persistent(qubo, &new_persistent, adjacency);
+        let previous_len = persistent.len();
+        propagate_persistent_in_place(qubo, &mut persistent, extra_fixed, adjacency);
 
-        if incoming_persistent.len() == previous_len {
+        if persistent.len() == previous_len {
             break;
         }
 
-        let incoming_persistent = solve_small_components(qubo, &incoming_persistent, 10);
-        if incoming_persistent.len() == previous_len {
+        solve_small_components_in_place_with_extra(qubo, &mut persistent, Some(extra_fixed), 10);
+        if persistent.len() == previous_len {
             break;
         }
-
-        new_persistent = incoming_persistent;
     }
 
-    new_persistent
+    persistent
 }
 
-fn propagate_persistent(
+fn propagate_persistent_in_place(
     qubo: &Qubo,
-    persistent: &FixedVarMap,
+    persistent: &mut FixedVarMap,
+    extra_fixed: &FixedVarMap,
     adjacency: &[Vec<(usize, f64)>],
-) -> FixedVarMap {
+) {
     let num_x = qubo.num_x();
-    let mut new_persistent = persistent.clone();
     let mut fixed_values = vec![None; num_x];
 
-    for (&index, &value) in persistent {
+    for (&index, &value) in persistent.iter() {
+        fixed_values[index] = Some(value as u8);
+    }
+    for (&index, &value) in extra_fixed.iter() {
         fixed_values[index] = Some(value as u8);
     }
 
@@ -80,11 +87,11 @@ fn propagate_persistent(
 
         if lower[i] > 0.0 {
             fixed_values[i] = Some(0);
-            new_persistent.insert(i, 0);
+            persistent.insert(i, 0);
             queue.push_back((i, 0u8));
         } else if upper[i] < 0.0 {
             fixed_values[i] = Some(1);
-            new_persistent.insert(i, 1);
+            persistent.insert(i, 1);
             queue.push_back((i, 1u8));
         }
     }
@@ -100,17 +107,15 @@ fn propagate_persistent(
 
             if lower[target] > 0.0 {
                 fixed_values[target] = Some(0);
-                new_persistent.insert(target, 0);
+                persistent.insert(target, 0);
                 queue.push_back((target, 0u8));
             } else if upper[target] < 0.0 {
                 fixed_values[target] = Some(1);
-                new_persistent.insert(target, 1);
+                persistent.insert(target, 1);
                 queue.push_back((target, 1u8));
             }
         }
     }
-
-    new_persistent
 }
 
 fn apply_free_term(lower: &mut f64, upper: &mut f64, coeff: f64) {

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -35,18 +35,20 @@ pub(crate) fn preprocess_with_prepared(
     prepared: &PreparedPreprocess,
     fixed_variables: &FixedVarMap,
 ) -> FixedVarMap {
-    let mut initial_fixed = fixed_variables.clone();
-
-    for (&key, &value) in &prepared.no_effect_vars {
-        initial_fixed.insert(key, value);
-    }
-
-    compute_iterative_persistence_with_adjacency(
+    let mut persistent = compute_iterative_persistence_with_adjacency(
         &prepared.qubo_pp,
-        &initial_fixed,
+        fixed_variables.clone(),
+        &prepared.no_effect_vars,
         prepared.qubo_pp.num_x(),
         &prepared.adjacency,
-    )
+    );
+
+    persistent.reserve(prepared.no_effect_vars.len());
+    for (&index, &value) in &prepared.no_effect_vars {
+        persistent.entry(index).or_insert(value);
+    }
+
+    persistent
 }
 
 /// This is the main entry point for preprocessing
@@ -134,11 +136,28 @@ pub fn solve_small_components(
     fixed_vars: &FixedVarMap,
     max_size: usize,
 ) -> FixedVarMap {
-    // copy the fixed variables
     let mut new_fixed_variables = fixed_vars.clone();
+    solve_small_components_in_place_with_extra(qubo, &mut new_fixed_variables, None, max_size);
+    new_fixed_variables
+}
 
+pub(crate) fn solve_small_components_in_place(
+    qubo: &Qubo,
+    fixed_vars: &mut FixedVarMap,
+    max_size: usize,
+) {
+    solve_small_components_in_place_with_extra(qubo, fixed_vars, None, max_size);
+}
+
+pub(crate) fn solve_small_components_in_place_with_extra(
+    qubo: &Qubo,
+    fixed_vars: &mut FixedVarMap,
+    extra_fixed_vars: Option<&FixedVarMap>,
+    max_size: usize,
+) {
     // get all the disconnected graphs
-    let components = crate::graph_utils::get_all_disconnected_graphs(qubo, &new_fixed_variables);
+    let components =
+        crate::graph_utils::get_all_disconnected_graphs_with_extra(qubo, fixed_vars, extra_fixed_vars);
 
     for component in components {
         // if the component is too large, skip it same with it being empty
@@ -147,24 +166,36 @@ pub fn solve_small_components(
         }
 
         // remove the fixed variables from the component
-        let (sub_qubo, mapping) = make_component_qubo(qubo, &component, &new_fixed_variables);
+        let (sub_qubo, mapping) = make_component_qubo_with_extra(
+            qubo,
+            &component,
+            fixed_vars,
+            extra_fixed_vars,
+        );
 
         // solve the subproblem via enumeration
         let (_, solution) = crate::subproblemsolvers::enumerate_qubo::enumerate_solve(&sub_qubo);
 
         // map the solution back to the original variables
         for (key, &value) in &mapping {
-            new_fixed_variables.insert(*key, solution[value]);
+            fixed_vars.insert(*key, solution[value]);
         }
     }
-
-    new_fixed_variables
 }
 
 pub fn make_component_qubo(
     qubo: &Qubo,
     component: &[usize],
     fixed_vars: &FixedVarMap,
+) -> (Qubo, VarMap) {
+    make_component_qubo_with_extra(qubo, component, fixed_vars, None)
+}
+
+pub fn make_component_qubo_with_extra(
+    qubo: &Qubo,
+    component: &[usize],
+    fixed_vars: &FixedVarMap,
+    extra_fixed_vars: Option<&FixedVarMap>,
 ) -> (Qubo, VarMap) {
     let mut Q_tri = TriMat::new((component.len(), component.len()));
     let mut c_new = Array1::<f64>::zeros(component.len());
@@ -178,19 +209,28 @@ pub fn make_component_qubo(
     }
 
     for (&value, (i, j)) in &qubo.q {
+        let fixed_i = fixed_vars
+            .get(&i)
+            .copied()
+            .or_else(|| extra_fixed_vars.and_then(|extra| extra.get(&i).copied()));
+        let fixed_j = fixed_vars
+            .get(&j)
+            .copied()
+            .or_else(|| extra_fixed_vars.and_then(|extra| extra.get(&j).copied()));
+
         match (
             index_map.get(&i),
             index_map.get(&j),
-            fixed_vars.get(&i),
-            fixed_vars.get(&j),
+            fixed_i,
+            fixed_j,
         ) {
             (Some(&i_new), Some(&j_new), _, _) => {
                 Q_tri.add_triplet(i_new, j_new, value);
             }
-            (Some(&i_new), None, _, Some(&fixed_j)) => {
+            (Some(&i_new), None, _, Some(fixed_j)) => {
                 c_new[i_new] += 0.5 * value * fixed_j as f64;
             }
-            (None, Some(&j_new), Some(&fixed_i), _) => {
+            (None, Some(&j_new), Some(fixed_i), _) => {
                 c_new[j_new] += 0.5 * value * fixed_i as f64;
             }
             _ => {}
@@ -303,6 +343,17 @@ mod tests {
         let fixed_variables = HashMap::default();
         let fixed_variables = preprocess_qubo(&p, &fixed_variables, false);
         assert_eq!(fixed_variables.len(), 3);
+    }
+
+    #[test]
+    fn test_preprocess_qubo_materializes_no_effect_variables() {
+        let p = Qubo::new_with_c(CsMat::zero((3, 3)), Array1::zeros(3));
+        let fixed_variables = preprocess_qubo(&p, &HashMap::default(), false);
+
+        assert_eq!(fixed_variables.len(), 3);
+        assert_eq!(fixed_variables.get(&0), Some(&0));
+        assert_eq!(fixed_variables.get(&1), Some(&0));
+        assert_eq!(fixed_variables.get(&2), Some(&0));
     }
 
     #[test]


### PR DESCRIPTION
fixed lower bound propagation so child nodes do not inherit weaker bounds
fixed equality pruning so zero-gap nodes actually die
fixed preprocess / persistence so no-effect vars get written back into the fixed var map
fixed branch variable fallback so branching rules do not fall back onto already-fixed variable 0
preserved the root heuristic run
switched the heuristic local search onto the faster improved descent path
removed the old duplicate two-step local search path